### PR TITLE
Scheduled scan report displays "IOException: Broken pipe" error for files too large to be scanned #24

### DIFF
--- a/application-antivirus-api/src/main/java/com/xwiki/antivirus/AntivirusConfiguration.java
+++ b/application-antivirus-api/src/main/java/com/xwiki/antivirus/AntivirusConfiguration.java
@@ -45,4 +45,9 @@ public interface AntivirusConfiguration
      *         no infection has been detected
      */
     boolean shouldAlwaysSendReport();
+
+    /**
+     * @return the maximum file size for which a scan should be performed at upload time
+     */
+    int getMaxFileSize();
 }

--- a/application-antivirus-api/src/main/java/com/xwiki/antivirus/AntivirusException.java
+++ b/application-antivirus-api/src/main/java/com/xwiki/antivirus/AntivirusException.java
@@ -36,4 +36,12 @@ public class AntivirusException extends Exception
     {
         super(message, cause);
     }
+
+    /**
+     * @param message the exception message
+     */
+    public AntivirusException(String message)
+    {
+        super(message);
+    }
 }

--- a/application-antivirus-api/src/main/java/com/xwiki/antivirus/internal/AntivirusJob.java
+++ b/application-antivirus-api/src/main/java/com/xwiki/antivirus/internal/AntivirusJob.java
@@ -27,6 +27,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.slf4j.Logger;
@@ -241,6 +242,15 @@ public class AntivirusJob extends AbstractJob
         } catch (Exception e) {
             // Log the exception.
             LOGGER.error("Failed to scan attachment [{}]", attachment.getReference(), e);
+            // Files larger than the ClamAV configured size (default 25MB) will fail to be scanned. Attempting to scan
+            // will throw the following errors. In the scan report we want to display a user friendly message, so we
+            // create a new exception.
+            String rootExceptionMessage = ExceptionUtils.getRootCauseMessage(e);
+            if (rootExceptionMessage.equals("IOException: Broken pipe") ||
+                rootExceptionMessage.equals("ScanFailureException: Scan failure: INSTREAM size limit exceeded. ERROR"))
+            {
+                e = new AntivirusException("File size too large");
+            }
             // Add it to the list of failed attachments, to be sent in the report.
             scanFailedAttachments.put(attachment, e);
             // Nothing more to do for this attachment.
@@ -265,7 +275,8 @@ public class AntivirusJob extends AbstractJob
 
         // Skip sending the report only when no infected attachments are found and report sending is not forced.
         if (!antivirusConfiguration.shouldAlwaysSendReport() && deletedInfectedAttachments.isEmpty()
-            && deleteFailedInfectedAttachments.isEmpty()) {
+            && deleteFailedInfectedAttachments.isEmpty())
+        {
             LOGGER.debug("No-infections scheduled scan report sending is skipped. 'Alway Send Report' is disabled.");
             return;
         }

--- a/application-antivirus-api/src/main/java/com/xwiki/antivirus/internal/AntivirusJobSchedulerListener.java
+++ b/application-antivirus-api/src/main/java/com/xwiki/antivirus/internal/AntivirusJobSchedulerListener.java
@@ -1,0 +1,151 @@
+/*
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package com.xwiki.antivirus.internal;
+
+import java.util.Collections;
+import java.util.List;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Provider;
+import javax.inject.Singleton;
+
+import org.quartz.SchedulerException;
+import org.quartz.Trigger.TriggerState;
+import org.xwiki.classloader.ClassLoaderManager;
+import org.xwiki.classloader.xwiki.internal.ContextNamespaceURLClassLoader;
+import org.xwiki.component.annotation.Component;
+import org.xwiki.component.phase.Initializable;
+import org.xwiki.component.phase.InitializationException;
+import org.xwiki.extension.event.ExtensionInstalledEvent;
+import org.xwiki.extension.repository.internal.installed.DefaultInstalledExtension;
+import org.xwiki.model.reference.LocalDocumentReference;
+import org.xwiki.observation.AbstractEventListener;
+import org.xwiki.observation.event.Event;
+import org.xwiki.wiki.descriptor.WikiDescriptorManager;
+
+import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
+import com.xpn.xwiki.doc.XWikiDocument;
+import com.xpn.xwiki.objects.BaseObject;
+import com.xpn.xwiki.plugin.scheduler.JobState;
+import com.xpn.xwiki.plugin.scheduler.SchedulerPlugin;
+
+/**
+ * Ensure that AntivirusJob is scheduled after antivirus install. Reschedule AntivirusJob to work around XWIKI-14494:
+ * 'Java scheduler job coming from an extension is not rescheduled when the extension is upgraded'. The unschedule /
+ * schedule process should be removed once the issue is fixed and licensing depends on a version of XWiki >= the version
+ * where is fixed.
+ *
+ * @version $Id$
+ * @since 1.4.3
+ */
+@Component
+@Named(AntivirusJobSchedulerListener.ROLE_HINT)
+@Singleton
+public class AntivirusJobSchedulerListener extends AbstractEventListener implements Initializable
+{
+    /**
+     * The role hint of this component.
+     */
+    public static final String ROLE_HINT = "AntivirusJobSchedulerListener";
+
+    /**
+     * The id of application-antivirus-api module.
+     */
+    protected static final String ANTIVIRUS_API_ID = "com.xwiki.antivirus:application-antivirus-api";
+
+    protected static final LocalDocumentReference JOB_DOC =
+        new LocalDocumentReference(Collections.singletonList("Antivirus"), "AntivirusJob");
+
+    private static final List<Event> EVENTS = Collections.singletonList(new ExtensionInstalledEvent());
+
+    @Inject
+    private Provider<XWikiContext> contextProvider;
+
+    @Inject
+    private WikiDescriptorManager wikiDescriptorManager;
+
+    @Inject
+    private ClassLoaderManager classLoaderManager;
+
+    public AntivirusJobSchedulerListener()
+    {
+        super(ROLE_HINT, EVENTS);
+    }
+
+    /**
+     * The unschedule / schedule process should be done at ExtensionUpgradedEvent, but for avoiding XCOMMONS-751:
+     * 'Getting wrong component instance during JAR extension upgrade' it is done at initialization step, since when the
+     * extension is initialized after an upgrade, all the extension's listeners are initialized. After the issue is
+     * fixed and licensing starts depending on a version of XWiki >= the version where is fixed, then this code should
+     * be moved inside a ExtensionUpgradedEvent listener.
+     *
+     * @see org.xwiki.component.phase.Initializable#initialize()
+     */
+    @Override
+    public void initialize() throws InitializationException
+    {
+        // Overwrite the Thread Context ClassLoader to work around the https://jira.xwiki.org/browse/XCOMMONS-2064 bug.
+        // Remove this hack once it's fixed and licensing starts depending on XWiki >= the version where it's fixed.
+        Thread.currentThread().setContextClassLoader(
+            new ContextNamespaceURLClassLoader(this.wikiDescriptorManager, this.classLoaderManager));
+
+        try {
+            // Don't trigger the rescheduling process at xwiki startup time.
+            if (this.contextProvider.get() != null) {
+                scheduleAutomaticUpgradesJob(true);
+            }
+        } catch (XWikiException | SchedulerException e) {
+            throw new InitializationException("Error while rescheduling AntivirusJob", e);
+        }
+    }
+
+    @Override public void onEvent(Event event, Object source, Object data)
+    {
+        String extensionId = ((DefaultInstalledExtension) source).getId().getId();
+
+        if (event instanceof ExtensionInstalledEvent && extensionId.equals(ANTIVIRUS_API_ID)) {
+            try {
+                scheduleAutomaticUpgradesJob(false);
+            } catch (XWikiException | SchedulerException e) {
+                throw new RuntimeException("Error while scheduling AntivirusJob after antivirus install",
+                    e);
+            }
+        }
+    }
+
+    protected void scheduleAutomaticUpgradesJob(boolean doReschedule) throws XWikiException, SchedulerException
+    {
+        XWikiContext xcontext = contextProvider.get();
+
+        SchedulerPlugin scheduler = (SchedulerPlugin) xcontext.getWiki().getPluginManager().getPlugin("scheduler");
+        XWikiDocument jobDoc = xcontext.getWiki().getDocument(JOB_DOC, xcontext);
+        BaseObject job = jobDoc.getXObject(SchedulerPlugin.XWIKI_JOB_CLASSREFERENCE);
+        JobState jobState = scheduler.getJobStatus(job, xcontext);
+
+        if (doReschedule && jobState.getQuartzState().equals(TriggerState.NORMAL)) {
+            scheduler.unscheduleJob(job, xcontext);
+            scheduler.scheduleJob(job, xcontext);
+        } else if (!doReschedule && jobState.getQuartzState().equals(TriggerState.NONE)) {
+            scheduler.scheduleJob(job, xcontext);
+        }
+    }
+}

--- a/application-antivirus-api/src/main/java/com/xwiki/antivirus/internal/AttachmentUploadedEventListener.java
+++ b/application-antivirus-api/src/main/java/com/xwiki/antivirus/internal/AttachmentUploadedEventListener.java
@@ -45,6 +45,7 @@ import org.xwiki.observation.event.CancelableEvent;
 import org.xwiki.observation.event.Event;
 
 import com.xpn.xwiki.XWikiContext;
+import com.xpn.xwiki.XWikiException;
 import com.xpn.xwiki.doc.AttachmentDiff;
 import com.xpn.xwiki.doc.XWikiAttachment;
 import com.xpn.xwiki.doc.XWikiDocument;
@@ -126,9 +127,10 @@ public class AttachmentUploadedEventListener extends AbstractEventListener
 
         // Skip if the license has expired.
         if (!licensorProvider.get()
-            .hasLicensure(new DocumentReference(context.getMainXWiki(), "Antivirus", "ConfigurationClass"))) {
+            .hasLicensure(new DocumentReference(context.getMainXWiki(), "Antivirus", "ConfigurationClass")))
+        {
             logger.warn("Skipping attachment scan for event [{}] by user [{}] on document [{}]. "
-                + "No valid Antivirus license has been found. Please visit the 'Licenses' section in Administration.",
+                    + "No valid Antivirus license has been found. Please visit the 'Licenses' section in Administration.",
                 event.getClass().getName(), context.getUserReference(), safeDoc.getDocumentReference());
             return;
         }
@@ -164,6 +166,15 @@ public class AttachmentUploadedEventListener extends AbstractEventListener
         Map<AttachmentReference, Collection<String>> infectedAttachments = new HashMap<>();
         for (XWikiAttachment attachment : attachmentsToScan) {
             try {
+                long attachmentSize = attachment.getContentLongSize(context);
+                int maxFileSize = antivirusConfiguration.getMaxFileSize();
+                if (attachmentSize > maxFileSize * 1_000_000L) {
+                    logger.warn(
+                        "Attachment [{}] is larger than [{}MB] and will be skipped during event [{}] by user [{}]."
+                            + " The file will be scanned during the scheduled scan.",
+                        attachment.getReference(), maxFileSize, event.getClass().getName(), context.getUserReference());
+                    continue;
+                }
                 ScanResult scanResult = antivirus.scan(attachment);
                 if (scanResult.isClean()) {
                     continue;
@@ -178,7 +189,7 @@ public class AttachmentUploadedEventListener extends AbstractEventListener
                 // Save the incident in the log.
                 antivirusLog.log(attachment, scanResult.getfoundViruses(), "blocked", "upload",
                     antivirusConfiguration.getDefaultEngineName());
-            } catch (AntivirusException e) {
+            } catch (AntivirusException | XWikiException e) {
                 logger.error("Failed to scan attachment [{}] during event [{}] by user [{}]", attachment.getReference(),
                     event.getClass().getName(), context.getUserReference(), e);
             }

--- a/application-antivirus-api/src/main/java/com/xwiki/antivirus/internal/DefaultAntivirusConfiguration.java
+++ b/application-antivirus-api/src/main/java/com/xwiki/antivirus/internal/DefaultAntivirusConfiguration.java
@@ -58,4 +58,10 @@ public class DefaultAntivirusConfiguration implements AntivirusConfiguration
     {
         return configuration.getProperty("alwaysSendReport", 1) == 1;
     }
+
+    @Override
+    public int getMaxFileSize()
+    {
+        return configuration.getProperty("maxFileSize", 25);
+    }
 }

--- a/application-antivirus-api/src/main/resources/META-INF/components.txt
+++ b/application-antivirus-api/src/main/resources/META-INF/components.txt
@@ -1,4 +1,5 @@
 com.xwiki.antivirus.internal.AntivirusConfigurationSource
+com.xwiki.antivirus.internal.AntivirusJobSchedulerListener
 com.xwiki.antivirus.internal.AttachmentUploadedEventListener
 com.xwiki.antivirus.internal.DefaultAntivirusConfiguration
 com.xwiki.antivirus.internal.DefaultAntivirusLog

--- a/application-antivirus-ui/src/main/resources/Antivirus/Administration.xml
+++ b/application-antivirus-ui/src/main/resources/Antivirus/Administration.xml
@@ -88,6 +88,15 @@
       $configDoc.display('alwaysSendReport', 'edit')
 
       {{html clean="false"}}&lt;/dd&gt;
+      &lt;dt&gt;
+        &lt;label for="Antivirus.ConfigurationClass_0_maxFileSize">$configClass.maxFileSize.translatedPrettyName&lt;/label&gt;
+        &lt;span class='xHint'&gt;$services.localization.render('Antivirus.ConfigurationClass_maxFileSize_hint')&lt;/span&gt;
+      &lt;/dt&gt;
+      &lt;dd&gt;{{/html}}
+
+      $configDoc.display('maxFileSize', 'edit')
+
+      {{html clean="false"}}&lt;/dd&gt;
     &lt;/dl&gt;
     &lt;div class='buttonwrapper'&gt;
       &lt;input value="$services.localization.render('admin.save')" class='button' type='submit'&gt;

--- a/application-antivirus-ui/src/main/resources/Antivirus/Configuration.xml
+++ b/application-antivirus-ui/src/main/resources/Antivirus/Configuration.xml
@@ -92,6 +92,20 @@
         <validationRegExp/>
         <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
       </enabled>
+      <maxFileSize>
+        <customDisplay/>
+        <disabled>0</disabled>
+        <hint/>
+        <name>maxFileSize</name>
+        <number>4</number>
+        <numberType>integer</numberType>
+        <prettyName>maxFileSize</prettyName>
+        <size>30</size>
+        <unmodifiable>0</unmodifiable>
+        <validationMessage/>
+        <validationRegExp/>
+        <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+      </maxFileSize>
     </class>
     <property>
       <alwaysSendReport>1</alwaysSendReport>
@@ -101,6 +115,9 @@
     </property>
     <property>
       <enabled>1</enabled>
+    </property>
+    <property>
+      <maxFileSize>25</maxFileSize>
     </property>
   </object>
 </xwikidoc>

--- a/application-antivirus-ui/src/main/resources/Antivirus/ConfigurationClass.xml
+++ b/application-antivirus-ui/src/main/resources/Antivirus/ConfigurationClass.xml
@@ -87,6 +87,20 @@
       <validationRegExp/>
       <classType>com.xpn.xwiki.objects.classes.BooleanClass</classType>
     </enabled>
+    <maxFileSize>
+      <customDisplay/>
+      <disabled>0</disabled>
+      <hint/>
+      <name>maxFileSize</name>
+      <number>4</number>
+      <numberType>integer</numberType>
+      <prettyName>maxFileSize</prettyName>
+      <size>30</size>
+      <unmodifiable>0</unmodifiable>
+      <validationMessage/>
+      <validationRegExp/>
+      <classType>com.xpn.xwiki.objects.classes.NumberClass</classType>
+    </maxFileSize>
   </class>
   <object>
     <name>Antivirus.ConfigurationClass</name>

--- a/application-antivirus-ui/src/main/resources/Antivirus/Translations.xml
+++ b/application-antivirus-ui/src/main/resources/Antivirus/Translations.xml
@@ -44,6 +44,8 @@ Antivirus.ConfigurationClass_defaultEngineName=Default Antivirus
 Antivirus.ConfigurationClass_defaultEngineName_hint=The antivirus engine to use during scanning. Use the Extension Manager to search for other implementations that you can install and use.
 Antivirus.ConfigurationClass_alwaysSendReport=Always Send Report
 Antivirus.ConfigurationClass_alwaysSendReport_hint=If the report at the end of a Scheduled Scan should always be sent to the admins, even when no infection has been detected.
+Antivirus.ConfigurationClass_maxFileSize=Maximum File Size
+Antivirus.ConfigurationClass_maxFileSize_hint=The maximum file size for which a scan should be performed at upload time.
 
 antivirus.extension.name=Antivirus Application
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <xwiki.jacoco.instructionRatio>0.00</xwiki.jacoco.instructionRatio>
     <xwiki.issueManagement.system>GitHub</xwiki.issueManagement.system>
     <xwiki.issueManagement.url>https://github.com/xwikisas/application-antivirus/issues</xwiki.issueManagement.url>
-    <licensing.version>1.22</licensing.version>
+    <licensing.version>1.22.1</licensing.version>
     <!-- Revapi produces too many false positives that come from transitive dependencies in platform. -->
     <xwiki.revapi.skip>true</xwiki.revapi.skip>
   </properties>


### PR DESCRIPTION
* When detecting the exception message specific to encountering large files, store in scanFailedAttachments map a new Exception containing the desired message "File size too large"
* Upgrade licensing app to version 1.22.1
* Also implemented issue #25

When encountering a file larger than the configured size at scheduled scan time, the report mail will look like so:

![image](https://user-images.githubusercontent.com/45433221/174283133-de329086-bdc8-4461-bc4f-1d0cea42eb59.png)


When uploading a file larger than the configured size, a WARNING will be displayed in the console:
`2022-06-17 13:22:30,414 [http://localhost:8080/xwiki/bin/upload/VirusTest/WebHome] WARN  ttachmentUploadedEventListener - Attachment [Attachment xwiki:VirusTest.WebHome@clamav-0.105.0.tar.gz] is larger than [25MB] and will be skipped during event [org.xwiki.bridge.event.DocumentUpdatingEvent] by user [xwiki:XWiki.superadmin]. The file will be scanned during the scheduled scan.`